### PR TITLE
fix: throws when xml string is a number

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,6 @@ export interface TraverseNestedObject {
 const xmlParser = new XMLParser({
   attributeNamePrefix: '@',
   ignoreAttributes: false,
-  parseAttributeValue: true,
 });
 
 const cacheNavPool: Record<string, TOCItem> = {


### PR DESCRIPTION
Fixes #22 

Passing tests still pass.

This changes the settings on fast-xml-parser so it doesn't cast strings to numbers.