### PR TITLE
Fix for numeric titles

### DIFF
--- a/src/parseEpub.ts
+++ b/src/parseEpub.ts
@@ -232,7 +232,8 @@ export class Epub {
     const parseNavPoint = (navPoint: GeneralObject) => {
       // link to section
       const path = _.get(navPoint, ['content', '@src'], '')
-      const name = _.get(navPoint, ['navLabel', 'text'])
+      const rawName = _.get(navPoint, ['navLabel', 'text'])
+      const name = rawName != null ? String(rawName) : ''
 
       const playOrder = _.get(navPoint, ['@playOrder']) as string
       const { hash } = parseLink(path)


### PR DESCRIPTION
I had a document where a chapter title was a year only as a number, so it failed due to type conversion path expecting a string, not a number, and this fixes that.