### PR TITLE
Graceful fallback for malformed TOC XML instead of crashing conversion

### DIFF
--- a/src/xml/index.ts
+++ b/src/xml/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path/posix'
+import logger from '../logger'
 import { parseMetaContainer } from './meta-container'
 import { Opf, parseOpf } from './opf'
 import { parseToc } from './toc'
@@ -36,8 +37,13 @@ class Parse {
   toc(opf: Opf, contentRoot: string) {
     const relativePath = opf.manifest.getById('ncx')?.href
     if (!relativePath) return
-    const fullPath = path.join(contentRoot, relativePath)
-    const string = this.zip.getFile(fullPath).asText()
-    return parseToc(string, (href) => opf.manifest.getItemId(href))
+    try {
+      const fullPath = path.join(contentRoot, relativePath)
+      const string = this.zip.getFile(fullPath).asText()
+      return parseToc(string, (href) => opf.manifest.getItemId(href))
+    } catch (error) {
+      logger.warn('Failed to read or parse TOC file, skipping TOC', error)
+      return undefined
+    }
   }
 }

--- a/src/xml/toc.ts
+++ b/src/xml/toc.ts
@@ -1,11 +1,18 @@
 import _ from 'lodash'
 import parseLink from '../parseLink'
+import logger from '../logger'
 import { GeneralObject } from '../types'
 import { parseXml } from './parseXml'
 import { Manifest } from './opf'
 
 export function parseToc(text: string, getItemId: Manifest['getItemId']) {
-  const object = parseXml(text) as any
+  let object: any
+  try {
+    object = parseXml(text)
+  } catch (error) {
+    logger.warn('Failed to parse TOC XML, skipping TOC', error)
+    return undefined
+  }
   const toc = object.html ? html(object, getItemId) : ncx(object, getItemId)
   return toc && new Toc(toc)
 }


### PR DESCRIPTION
Fixes issue where fast-xml-parser throws TypeError: Cannot read properties of undefined (reading 'tagName') on certain malformed/truncated TOC XML, which kills the entire epub conversion.